### PR TITLE
refactor: replace interface{} with any

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -30,13 +30,13 @@ type Conf interface {
 	// Keys returns the list of the stored keys
 	Keys() []string
 	// SetDefault sets a default value for a key
-	SetDefault(key string, value interface{}) Conf
+	SetDefault(key string, value any) Conf
 	// Set overrides the current value of a given key.
-	Set(key string, value interface{}) Conf
+	Set(key string, value any) Conf
 	// Get returns a value for a given key if it is set or default value
 	// Returns `nil` if key not found
 
-	Get(key string) interface{}
+	Get(key string) any
 	// GetString casts a value for a given key to String
 	GetString(key string) string
 	// GetInt casts a value for a given key to Int
@@ -123,8 +123,8 @@ func (c *conf) Reset() Conf {
 	)
 	s := (*sync.Map)(old)
 
-	var keys []interface{}
-	s.Range(func(key, value interface{}) bool {
+	var keys []any
+	s.Range(func(key, value any) bool {
 		keys = append(keys, key)
 		return true
 	})
@@ -156,7 +156,7 @@ func (c *conf) Load(ctx context.Context) error {
 	return nil
 }
 
-func (c *conf) scan(data interface{}, key string) {
+func (c *conf) scan(data any, key string) {
 	if key != "" {
 		c.storage.Store(key, data)
 		key += "."
@@ -187,12 +187,12 @@ func Keys() []string {
 func (c *conf) Keys() []string {
 	var keys []string
 
-	c.storage.Range(func(key, value interface{}) bool {
+	c.storage.Range(func(key, value any) bool {
 		keys = append(keys, key.(string))
 		return true
 	})
 
-	c.defaults.Range(func(key, value interface{}) bool {
+	c.defaults.Range(func(key, value any) bool {
 		keys = append(keys, key.(string))
 		return true
 	})
@@ -202,22 +202,22 @@ func (c *conf) Keys() []string {
 
 // SetDefault sets a default value for a key
 // The alias to work with an instance of the global configuration manager.
-func SetDefault(key string, value interface{}) Conf {
+func SetDefault(key string, value any) Conf {
 	return globalConf.SetDefault(key, value)
 }
 
-func (c *conf) SetDefault(key string, value interface{}) Conf {
+func (c *conf) SetDefault(key string, value any) Conf {
 	c.defaults.Store(key, value)
 	return c
 }
 
 // Set overrides the current value of a given key.
 // The alias to work with an instance of the global configuration manager.
-func Set(key string, value interface{}) Conf {
+func Set(key string, value any) Conf {
 	return globalConf.Set(key, value)
 }
 
-func (c *conf) Set(key string, value interface{}) Conf {
+func (c *conf) Set(key string, value any) Conf {
 	c.storage.Store(key, value)
 	return c
 }
@@ -225,11 +225,11 @@ func (c *conf) Set(key string, value interface{}) Conf {
 // Get returns a value for a given key if it is set or default value
 // Returns `nil` if key not found
 // The alias to work with an instance of the global configuration manager.
-func Get(key string) interface{} {
+func Get(key string) any {
 	return globalConf.Get(key)
 }
 
-func (c *conf) Get(key string) interface{} {
+func (c *conf) Get(key string) any {
 	value, ok := c.storage.Load(key)
 	if !ok {
 		value, _ = c.defaults.Load(key)

--- a/conf_test.go
+++ b/conf_test.go
@@ -14,11 +14,11 @@ import (
 
 type testReader struct {
 	err    error
-	data   interface{}
+	data   any
 	prefix string
 }
 
-func (t *testReader) Read(_ context.Context) (interface{}, error) {
+func (t *testReader) Read(_ context.Context) (any, error) {
 	return t.data, t.err
 }
 
@@ -26,7 +26,7 @@ func (t *testReader) Prefix() string {
 	return t.prefix
 }
 
-func newReader(tb testing.TB, prefix string, data interface{}, err error) conf.Reader {
+func newReader(tb testing.TB, prefix string, data any, err error) conf.Reader {
 	tb.Helper()
 
 	return &testReader{prefix: prefix, data: data, err: err}
@@ -37,12 +37,12 @@ var errFake = errors.New("fake error")
 func TestConf(t *testing.T) {
 	t.Parallel()
 
-	data1 := map[string]interface{}{
+	data1 := map[string]any{
 		"foo": "bar",
 		"baz": 42,
 		"xyz": []int{1, 2, 3},
-		"a": map[string]interface{}{
-			"b": []map[string]interface{}{
+		"a": map[string]any{
+			"b": []map[string]any{
 				{
 					"c": 1,
 				},
@@ -55,7 +55,7 @@ func TestConf(t *testing.T) {
 	}
 	data2 := "fake data"
 	data3 := 34
-	data4 := []interface{}{
+	data4 := []any{
 		1,
 		"2",
 	}
@@ -157,7 +157,7 @@ func TestConf_GetBool(t *testing.T) {
 	t.Parallel()
 
 	c := conf.New()
-	data := map[interface{}]bool{
+	data := map[any]bool{
 		"0":     false,
 		"1":     true,
 		0:       false,
@@ -192,7 +192,7 @@ func TestConf_GetString(t *testing.T) {
 	t.Parallel()
 
 	c := conf.New()
-	data := map[interface{}]string{
+	data := map[any]string{
 		"0":   "0",
 		"1":   "1",
 		0:     "0",
@@ -214,7 +214,7 @@ func TestConf_GetInt(t *testing.T) {
 	t.Parallel()
 
 	c := conf.New()
-	data := map[interface{}]int{
+	data := map[any]int{
 		"0":   0,
 		"-1":  -1,
 		0:     0,
@@ -244,7 +244,7 @@ func TestConf_GetFloat(t *testing.T) {
 	t.Parallel()
 
 	c := conf.New()
-	data := map[interface{}]float64{
+	data := map[any]float64{
 		"0.1":  0.1,
 		"-1.4": -1.4,
 		0:      0,
@@ -273,7 +273,7 @@ func TestConf_GetTime(t *testing.T) {
 	require.NoError(t, err)
 
 	c := conf.New()
-	data := map[interface{}]time.Time{
+	data := map[any]time.Time{
 		"0.1":                  {},
 		"-1.4":                 {},
 		0:                      time.Unix(0, 0),
@@ -300,7 +300,7 @@ func TestConf_GetDuration(t *testing.T) {
 	t.Parallel()
 
 	c := conf.New()
-	data := map[interface{}]time.Duration{
+	data := map[any]time.Duration{
 		"0.1":                  0,
 		"-1.4":                 -1,
 		0:                      0,
@@ -330,7 +330,7 @@ func TestGlobalConf(t *testing.T) {
 	})
 
 	require.Nil(t, conf.Get("foo"))
-	conf.WithReaders(newReader(t, "", map[string]interface{}{
+	conf.WithReaders(newReader(t, "", map[string]any{
 		"foo": 42,
 	}, nil))
 	require.NoError(t, conf.Load(t.Context()))
@@ -364,7 +364,7 @@ func TestGlobalConf(t *testing.T) {
 	require.ElementsMatch(t, []string{"foo", "bar", "xyz", "default"}, conf.Keys())
 }
 
-func testTransform(_ string, value interface{}, _ conf.Conf) interface{} {
+func testTransform(_ string, value any, _ conf.Conf) any {
 	if v, ok := value.(string); ok && v == "value-to-be-transformed" {
 		return 101
 	}

--- a/parser.go
+++ b/parser.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ParseFunc is a type for the parsing function
-type ParseFunc func(ctx context.Context, r io.Reader) (interface{}, error)
+type ParseFunc func(ctx context.Context, r io.Reader) (any, error)
 
 // Parser is an extension for the Reader interface.
 type Parser interface {
@@ -35,7 +35,7 @@ var (
 	ErrNoStream = errors.New("no data stream")
 )
 
-func (p *parser) Read(ctx context.Context) (interface{}, error) {
+func (p *parser) Read(ctx context.Context) (any, error) {
 	if p.stream == nil {
 		return nil, ErrNoStream
 	}

--- a/parset_test.go
+++ b/parset_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sv-tools/conf"
 )
 
-func testParseFunc(_ context.Context, r io.Reader) (interface{}, error) {
+func testParseFunc(_ context.Context, r io.Reader) (any, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -26,7 +26,7 @@ func testParseFunc(_ context.Context, r io.Reader) (interface{}, error) {
 	return res, nil
 }
 
-func testParseFuncError(_ context.Context, _ io.Reader) (interface{}, error) {
+func testParseFuncError(_ context.Context, _ io.Reader) (any, error) {
 	return nil, errFake
 }
 

--- a/reader.go
+++ b/reader.go
@@ -7,7 +7,7 @@ import (
 // Reader is an interface for the configuration readers
 type Reader interface {
 	// Read reads the data and returns a raw data
-	Read(ctx context.Context) (interface{}, error)
+	Read(ctx context.Context) (any, error)
 	// Prefix returns a prefix to be used for all keys of the values provided by the reader
 	Prefix() string
 }

--- a/transformer.go
+++ b/transformer.go
@@ -1,4 +1,4 @@
 package conf
 
 // Transform is a function to transform the data
-type Transform func(key string, value interface{}, c Conf) interface{}
+type Transform func(key string, value any, c Conf) any


### PR DESCRIPTION
Update all occurrences of interface{} to any in function signatures,
methods, and variables across the codebase. This change improves type
expressiveness and aligns with modern Go conventions introduced in
Go 1.18, enhancing readability and maintainability without altering
functionality.